### PR TITLE
Add engines support in package.json

### DIFF
--- a/src/components/DependencyTable.js
+++ b/src/components/DependencyTable.js
@@ -75,6 +75,7 @@ export default class DependencyTable extends React.Component {
               <th><abbr title="Core dependency count">Core dep.</abbr></th>
               <th><abbr title="Peer dependency count">Peer dep.</abbr></th>
               <th><abbr title="Dev dependency count">Dev dep.</abbr></th>
+              <th><abbr title="Engines dependency count">Engines dep.</abbr></th>
               <th className="repos">Repos</th>
               <th className="funding">Funding</th>
             </tr>
@@ -87,6 +88,7 @@ export default class DependencyTable extends React.Component {
                 <td>{dep.core}</td>
                 <td>{dep.peer}</td>
                 <td>{dep.dev}</td>
+                <td>{dep.engines}</td>
                 <td className="repos">
                   <List
                     array={dep.repos}

--- a/src/lib/dependencies/npm.js
+++ b/src/lib/dependencies/npm.js
@@ -10,6 +10,7 @@ const dependencyTypes = {
   core: 'dependencies',
   peer: 'peerDependencies',
   dev: 'devDependencies',
+  engines: 'engines',
 };
 
 function dependenciesStats (packageJson) {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -4,7 +4,7 @@ import { getDependenciesFromGithubRepo } from './dependencies';
 
 import allProjects from '../data/projects.json';
 
-const dependencyTypes = ['core', 'peer', 'dev'];
+const dependencyTypes = ['core', 'peer', 'dev', 'engines'];
 
 async function addDependenciesToRepo (repo, accessToken) {
   repo.dependencies = await getDependenciesFromGithubRepo(repo, accessToken);


### PR DESCRIPTION
Hey all...

Was following an [issue from Ghost](https://github.com/TryGhost/Ghost/issues/9743) that I thought was fun.

Changes basically aimed to recognize `engines` field in package.json

Also had to run `update-projects`, so that ghost entry shows up :)

Made a [test repo](https://github.com/v1adko/back-your-stack-engines-test) and it seems to work just fine.

![screen shot 2018-08-11 at 11 51 41 am](https://user-images.githubusercontent.com/11582927/43990007-a9b37124-9d5d-11e8-92c6-6ae4f020e805.png)