### PR TITLE
Add public repositories dependencies file url to repo object.

### DIFF
--- a/src/lib/data.js
+++ b/src/lib/data.js
@@ -37,12 +37,14 @@ export async function getProfileData(id, accessToken) {
   const repos = await fetchReposForProfile(profile, accessToken).then(repos =>
     Promise.all(
       repos.map(async repo => {
-        const dependencies = await getDependenciesFromGithubRepo(
+        const { dependencies, fileUrls } = await getDependenciesFromGithubRepo(
           repo,
           accessToken,
         );
         // eslint-disable-next-line require-atomic-updates
         repo.dependencies = dependencies;
+        // eslint-disable-next-line require-atomic-updates
+        repo.dependencies_file_urls = fileUrls;
         return repo;
       }),
     ),
@@ -51,7 +53,7 @@ export async function getProfileData(id, accessToken) {
   const dependencies = await addProjectToDependencies(
     getAllDependenciesFromRepos(repos),
   );
-
+  console.log('I was here');
   const recommendations = await getRecommendedProjectFromDependencies(
     dependencies,
   );

--- a/src/lib/dependencies/bundler.js
+++ b/src/lib/dependencies/bundler.js
@@ -7,7 +7,12 @@ function dependencies(file) {
   const gemfile = interpret(file.text);
   const core = Object.keys(gemfile['DEPENDENCIES'] || {});
   const peer = difference(Object.keys(gemfile['GEM'].specs || {}), core);
-  return { core, peer };
+  const dependencies = { core, peer };
+
+  return {
+    dependencies,
+    fileUrl: file.fileUrl || null,
+  };
 }
 
 function detectProjectName() {

--- a/src/lib/dependencies/composer.js
+++ b/src/lib/dependencies/composer.js
@@ -12,7 +12,10 @@ function json(file) {
 }
 
 function dependencies(file) {
-  return dependencyObject(json(file));
+  return {
+    dependencies: dependencyObject(json(file)),
+    fileUrl: file.fileUrl || null,
+  };
 }
 
 function detectProjectName(file) {

--- a/src/lib/dependencies/data.js
+++ b/src/lib/dependencies/data.js
@@ -40,27 +40,19 @@ export async function getFirstMatchingFiles(
   githubAccessToken,
 ) {
   for (const pattern of manager.patterns) {
-    let fileContents;
+    let files;
     if (manager.searchAllRepo) {
-      fileContents = await searchFilesFromRepo(
-        githubRepo,
-        pattern,
-        githubAccessToken,
-      );
+      files = await searchFilesFromRepo(githubRepo, pattern, githubAccessToken);
     } else {
-      fileContents = await fetchFileFromRepo(
-        githubRepo,
-        pattern,
-        githubAccessToken,
-      )
-        .then(content => [content])
+      files = await fetchFileFromRepo(githubRepo, pattern, githubAccessToken)
+        .then(file => [file])
         .catch(() => []);
     }
-
-    if (fileContents.length) {
-      return fileContents.map(text => ({
+    if (files.length) {
+      return files.map(({ content, fileUrl }) => ({
         matchedPattern: pattern,
-        text,
+        text: content,
+        fileUrl: fileUrl,
       }));
     }
   }

--- a/src/lib/dependencies/dep.js
+++ b/src/lib/dependencies/dep.js
@@ -17,7 +17,11 @@ function gopkgTomlDependencies(data) {
 
 function dependencies(file) {
   const data = toml.parse(file.text);
-  return { core: handlers[file.matchedPattern](data) };
+  const dependencies = { core: handlers[file.matchedPattern](data) };
+  return {
+    dependencies,
+    fileUrl: file.fileUrl || null,
+  };
 }
 
 function detectProjectName() {

--- a/src/lib/dependencies/npm.js
+++ b/src/lib/dependencies/npm.js
@@ -14,7 +14,10 @@ function json(file) {
 }
 
 function dependencies(file) {
-  return dependencyObject(json(file));
+  return {
+    dependencies: dependencyObject(json(file)),
+    fileUrl: file.fileUrl || null,
+  };
 }
 
 function detectProjectName(file) {

--- a/src/lib/dependencies/nuget.js
+++ b/src/lib/dependencies/nuget.js
@@ -28,7 +28,12 @@ function packagesConfigDependencies(packagesConfig) {
 
 function dependencies(file) {
   const xml = new xmldoc.XmlDocument(file.text);
-  return { core: handlers[file.matchedPattern](xml) };
+  const dependencies = { core: handlers[file.matchedPattern](xml) };
+
+  return {
+    dependencies,
+    fileUrl: file.fileUrl || null,
+  };
 }
 
 function detectProjectName(file) {

--- a/src/lib/dependencies/utils.js
+++ b/src/lib/dependencies/utils.js
@@ -5,8 +5,10 @@ import dependencyManagers from './dependency-managers';
 // Assumes dependencyObject is {core: ['dependency', ...], ...}
 // Returns [{type: 'npm', name: 'dependency', core: 1}, ...]
 export function transformToStats(manager, ...dependencyObjects) {
-  const index = {};
-  dependencyObjects.forEach(dependencies => {
+  const index = {},
+    fileUrls = [];
+  dependencyObjects.forEach(({ dependencies, fileUrl }) => {
+    fileUrls.push(fileUrl);
     Object.entries(dependencies).forEach(
       ([dependencyType, dependencyNames]) => {
         dependencyNames.forEach(name => {
@@ -16,7 +18,7 @@ export function transformToStats(manager, ...dependencyObjects) {
       },
     );
   });
-  return Object.values(index);
+  return { dependencies: Object.values(index), fileUrls };
 }
 
 export function dependenciesStats(file) {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -14,29 +14,30 @@ function getProjectFromDependency(name, type) {
 
 function getAllDependenciesFromRepos(repos) {
   const dependencies = [];
-
   for (const repo of repos) {
-    for (const dependency of repo.dependencies) {
-      const id = `${dependency.type}_${dependency.name}`;
-      dependencies[id] = dependencies[id] || pick(dependency, ['type', 'name']);
-      // Count all occurences of each dependency
-      for (const dependencyType of dependencyTypes) {
-        dependencies[id][dependencyType] =
-          dependencies[id][dependencyType] || 0;
-        if (dependency[dependencyType]) {
-          dependencies[id][dependencyType] += dependency[dependencyType];
+    if (repo.dependencies) {
+      for (const dependency of repo.dependencies) {
+        const id = `${dependency.type}_${dependency.name}`;
+        dependencies[id] =
+          dependencies[id] || pick(dependency, ['type', 'name']);
+        // Count all occurences of each dependency
+        for (const dependencyType of dependencyTypes) {
+          dependencies[id][dependencyType] =
+            dependencies[id][dependencyType] || 0;
+          if (dependency[dependencyType]) {
+            dependencies[id][dependencyType] += dependency[dependencyType];
+          }
         }
+        // Keep track of repos
+        dependencies[id]['repos'] = dependencies[id]['repos'] || {};
+        dependencies[id]['repos'][repo.id] = pick(repo, [
+          'id',
+          'name',
+          'full_name',
+        ]);
       }
-      // Keep track of repos
-      dependencies[id]['repos'] = dependencies[id]['repos'] || {};
-      dependencies[id]['repos'][repo.id] = pick(repo, [
-        'id',
-        'name',
-        'full_name',
-      ]);
     }
   }
-
   // Convert objects with ids as key to arrays
   return Object.values(dependencies).map(dependency => {
     dependency.repos = Object.values(dependency.repos);


### PR DESCRIPTION
As part of  https://github.com/opencollective/backyourstack/issues/183#issuecomment-521570828 tasks, this PR allows public repo object to have `dependencies_file_urls` property (an array of all dependencies raw file urls within a repo on Github). Because of the way the methods are connected in `getProfileData`, this PR required modifying few files but the main source in this modification is [`fetchFileFromRepo`](https://github.com/opencollective/backyourstack/blob/feat/organization/src/lib/github.js#L238) method.


![screenshot](https://user-images.githubusercontent.com/15707013/63259974-b7ad5e80-c277-11e9-9476-3c7e7d8c341f.png)
