### PR TITLE
Approach 2: Saving profile on s3 

### DIFF
--- a/src/lib/data.js
+++ b/src/lib/data.js
@@ -10,7 +10,10 @@ import {
   getRecommendedProjectFromDependencies,
 } from './utils';
 
-import { getDependenciesFromGithubRepo } from './dependencies/data';
+import {
+  getDependenciesFromGithubRepo,
+  fetchDependenciesFileContent,
+} from './dependencies/data';
 import { dependenciesStats } from './dependencies/utils';
 
 import githubToOpenCollectiveMapping from '../data/githubToOpenCollectiveMapping.json';
@@ -63,6 +66,10 @@ export async function getProfileData(id, accessToken) {
     dependencies,
     recommendations,
   };
+}
+
+export function getDependenciesFileContent(repo, accessToken) {
+  return fetchDependenciesFileContent(repo, accessToken);
 }
 
 export async function getFilesData(sessionFiles) {

--- a/src/lib/data.js
+++ b/src/lib/data.js
@@ -10,10 +10,7 @@ import {
   getRecommendedProjectFromDependencies,
 } from './utils';
 
-import {
-  getDependenciesFromGithubRepo,
-  fetchDependenciesFileContent,
-} from './dependencies/data';
+import { getDependenciesFromGithubRepo } from './dependencies/data';
 import { dependenciesStats } from './dependencies/utils';
 
 import githubToOpenCollectiveMapping from '../data/githubToOpenCollectiveMapping.json';
@@ -66,10 +63,6 @@ export async function getProfileData(id, accessToken) {
     dependencies,
     recommendations,
   };
-}
-
-export function getDependenciesFileContent(repo, accessToken) {
-  return fetchDependenciesFileContent(repo, accessToken);
 }
 
 export async function getFilesData(sessionFiles) {

--- a/src/lib/dependencies/data.js
+++ b/src/lib/dependencies/data.js
@@ -34,6 +34,19 @@ export function getDependenciesFromGithubRepo(githubRepo, githubAccessToken) {
   });
 }
 
+export function fetchDependenciesFileContent(githubRepo, githubAccessToken) {
+  const fileType = languageToFileType[githubRepo.language];
+  const manager = dependencyManagers[fileType];
+  return getFirstMatchingFiles(manager, githubRepo, githubAccessToken).catch(
+    err => {
+      logger.error(
+        `${fileType}.getDependenciesFromGithubRepo error: ${err.message}`,
+      );
+      return [];
+    },
+  );
+}
+
 export async function getFirstMatchingFiles(
   manager,
   githubRepo,

--- a/src/lib/s3.js
+++ b/src/lib/s3.js
@@ -59,16 +59,16 @@ export const saveProfileFiles = async (profileId, files) => {
   return savedFileUrls;
 };
 
-export const getObjectList = uuid => {
+export const getObjectList = id => {
   const params = {
     Bucket,
-    Prefix: `${uuid}/`,
+    Prefix: `${id}/`,
   };
   return s3.listObjects(params).promise();
 };
 
-export const getFiles = async uuid => {
-  const { Contents } = await getObjectList(uuid);
+export const getFiles = async id => {
+  const { Contents } = await getObjectList(id);
   const data = {};
 
   if (Contents.length === 0) {

--- a/src/lib/s3.js
+++ b/src/lib/s3.js
@@ -33,6 +33,32 @@ export const saveFileToS3 = (Key, Body) => {
   return s3.upload(uploadParam).promise();
 };
 
+export const saveProfile = async (profileId, repos) => {
+  const metaData = { profile: true, files: {} };
+  for (const repo of repos) {
+    if (repo.files) {
+      const savedFileUrls = await saveProfileFiles(profileId, repo.files);
+      metaData.files[repo.name] = {
+        urls: [savedFileUrls],
+        private: repo.private,
+      };
+    }
+  }
+  const key = `${profileId}/dependencies.json`;
+  return saveFileToS3(key, metaData);
+};
+
+export const saveProfileFiles = async (profileId, files) => {
+  const savedFileUrls = [];
+  for (const file of files) {
+    const key = `${profileId}/${uuidv1()}.json`;
+    const body = { [file.id]: file };
+    const data = await saveFileToS3(key, body);
+    savedFileUrls.push(data.Location);
+  }
+  return savedFileUrls;
+};
+
 export const getObjectList = uuid => {
   const params = {
     Bucket,

--- a/src/pages/files.js
+++ b/src/pages/files.js
@@ -100,7 +100,7 @@ export default class Files extends React.Component {
       const savedFileUrl = await this.saveFileToS3();
       const uuid = savedFileUrl.Key.split('/')[0];
       await Router.pushRoute('monthly-plan', {
-        uuid,
+        id: uuid,
       });
     } catch (err) {
       console.error(err);

--- a/src/pages/monthly-plan.js
+++ b/src/pages/monthly-plan.js
@@ -17,7 +17,7 @@ const getFilesData = sessionFiles =>
 
 export default class MonthlyPlan extends React.Component {
   static async getInitialProps({ req, query }) {
-    const uuid = query.uuid; // handle case where the uuid is not supplied
+    const id = query.Id;
 
     let protocol = 'https:';
     const host = req ? req.headers.host : window.location.host;
@@ -31,7 +31,7 @@ export default class MonthlyPlan extends React.Component {
     const { recommendations } = await getFilesData(sessionFiles);
 
     return {
-      uuid,
+      id,
       baseUrl,
       recommendations,
       next: query.next || '/',
@@ -39,7 +39,7 @@ export default class MonthlyPlan extends React.Component {
   }
 
   static propTypes = {
-    uuid: PropTypes.string,
+    id: PropTypes.string,
     baseUrl: PropTypes.string,
     loggedInUser: PropTypes.object,
     recommendations: PropTypes.array,
@@ -47,9 +47,9 @@ export default class MonthlyPlan extends React.Component {
 
   getContributionUrl = () => {
     // Get the key url of the file
-    const { baseUrl, uuid } = this.props;
-    if (uuid) {
-      const jsonUrl = `${baseUrl}/${uuid}/file/backing.json`;
+    const { baseUrl, id } = this.props;
+    if (id) {
+      const jsonUrl = `${baseUrl}/${id}/file/backing.json`;
       const data = JSON.stringify({ jsonUrl });
       const redirect = `${baseUrl}/monthly-plan/confirmation`;
       const searchParams = new URLSearchParams({ data, redirect });

--- a/src/pages/profile.js
+++ b/src/pages/profile.js
@@ -88,7 +88,7 @@ export default class Profile extends React.Component {
       const savedProfileUrl = await this.saveProfileToS3();
       const profileId = savedProfileUrl.Key.split('/')[0];
       await Router.pushRoute('monthly-plan', {
-        profileId,
+        id: profileId,
       });
     } catch (err) {
       console.error(err);

--- a/src/pages/profile.js
+++ b/src/pages/profile.js
@@ -4,9 +4,9 @@ import classNames from 'classnames';
 import NextLink from 'next/link';
 import { get } from 'lodash';
 
-import { Link } from '../routes';
+import { Link, Router } from '../routes';
 
-import { fetchJson } from '../lib/fetch';
+import { fetchJson, postJson } from '../lib/fetch';
 
 import Header from '../components/Header';
 import Footer from '../components/Footer';
@@ -15,6 +15,7 @@ import DependencyTable from '../components/DependencyTable';
 import RepositoryTable from '../components/RepositoryTable';
 import RecommendationList from '../components/RecommendationList';
 import SubscribeForm from '../components/SubscribeForm';
+import BackMyStack from '../components/BackMyStack';
 
 import TwitterLogo from '../static/img/twitter.svg';
 import FacebookLogo from '../static/img/facebook.svg';
@@ -28,7 +29,7 @@ const getProfileData = (id, accessToken) =>
 
 export default class Profile extends React.Component {
   static async getInitialProps({ req, query }) {
-    const initialProps = { section: query.section };
+    const initialProps = { section: query.section, id: query.id };
     try {
       // The accessToken is only required server side (it's ok if it's undefined on client side)
       const accessToken = get(req, 'session.passport.user.accessToken');
@@ -50,6 +51,7 @@ export default class Profile extends React.Component {
     dependencies: PropTypes.array,
     recommendations: PropTypes.array,
     error: PropTypes.object,
+    id: PropTypes.string,
   };
 
   twitterText = () => 'BackYourStack! https://backyourstack.com/';
@@ -75,6 +77,24 @@ export default class Profile extends React.Component {
     return githubProfileName;
   };
 
+  saveProfileToS3() {
+    const { id } = this.props;
+
+    return postJson('/profile/save', { id });
+  }
+
+  handleBackMyStack = async () => {
+    try {
+      const savedProfileUrl = await this.saveProfileToS3();
+      const profileId = savedProfileUrl.Key.split('/')[0];
+      await Router.pushRoute('monthly-plan', {
+        profileId,
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   render() {
     const {
       section,
@@ -87,6 +107,7 @@ export default class Profile extends React.Component {
       pathname,
       loggedInUser,
     } = this.props;
+
     return (
       <div className="Page ProfilePage">
         <style jsx global>
@@ -267,6 +288,7 @@ export default class Profile extends React.Component {
             </aside>
 
             <main>
+              <BackMyStack onClickBackMyStack={this.handleBackMyStack} />
               {(!section || section === 'recommendations') && (
                 <RecommendationList
                   recommendations={recommendations}

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -29,8 +29,8 @@ import {
   getProfileData,
   getFilesData,
   emailSubscribe,
-  getDependenciesFileContent,
 } from '../lib/data';
+import { fetchDependenciesFileContent } from '../lib/dependencies/data';
 import { uploadFiles, getFiles, saveProfile } from '../lib/s3';
 
 const {
@@ -208,13 +208,9 @@ nextApp.prepare().then(() => {
   server.post('/profile/save', async (req, res) => {
     const id = get(req, 'body.id');
     const accessToken = get(req, 'session.passport.user.accessToken');
-    if (!accessToken) {
-      res.setHeader('Cache-Control', 's-maxage=3600, max-age=0');
-    }
-
     const { repos, profile } = await getProfileData(id, accessToken);
     for (const repo of repos) {
-      let files = await getDependenciesFileContent(repo, accessToken);
+      let files = await fetchDependenciesFileContent(repo, accessToken);
       if (files.length) {
         files = files.map(({ matchedPattern, text }) => {
           const file = { name: matchedPattern, text };

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -257,14 +257,14 @@ nextApp.prepare().then(() => {
     res.send(backing);
   });
 
-  server.get('/:uuid/file/backing.json', async (req, res) => {
-    if (!req.params.uuid) {
+  server.get('/:id/file/backing.json', async (req, res) => {
+    if (!req.params.id) {
       return res.status(400).send('Please provide the file key');
     }
     let data;
 
     try {
-      data = await getFiles(req.params.uuid);
+      data = await getFiles(req.params.id);
     } catch (err) {
       console.error(err);
       return res.status(400).send('Unable to fetch file');


### PR DESCRIPTION
This PR follows the 2nd approach of saving profile in https://github.com/opencollective/backyourstack/issues/183#issuecomment-521570828, originally in the plan, I proposed caching the content of the files during the initial dependencies load and retrieving it during "BackMyStack" but after reading through the type and limitations of our current caching system  I decided to opt out of that and directly fetch contents with [`fetchDependenciesFileContent`](https://github.com/opencollective/backyourstack/blob/feat/saving-private-repo/src/lib/dependencies/data.js#L37) I created.

The contents are then constructed in similar data structure of anonymous file before being saved. Additional metadata like `profile: true`  and `private: true` are added in the `[profile Id]/dependencies.json`.

NOTE: This approach works for both private and public repository although it was originally proposed for private. Also worthy of note is the change in term i.e I changed from using `organization` to `profile` because as an individual I want to also BackMystack. Profile can be individual or organization.

TODO: 

- [ ] In monthly-plan page, get the opencollective id and handle `/profileId/backing.json` enpoint.



