### PR TITLE
Use different json url for profile and file

### DIFF
--- a/src/pages/monthly-plan.js
+++ b/src/pages/monthly-plan.js
@@ -91,12 +91,14 @@ export default class MonthlyPlan extends React.Component {
       id,
       baseUrl,
       recommendations,
+      type,
       next: query.next || '/',
     };
   }
 
   static propTypes = {
     id: PropTypes.string,
+    type: PropTypes.string,
     baseUrl: PropTypes.string,
     loggedInUser: PropTypes.object,
     recommendations: PropTypes.array,
@@ -125,9 +127,12 @@ export default class MonthlyPlan extends React.Component {
 
   getContributionUrl = () => {
     // Get the key url of the file
-    const { baseUrl, id } = this.props;
+    const { baseUrl, id, type } = this.props;
     if (id) {
-      const jsonUrl = `${baseUrl}/${id}/file/backing.json`;
+      const jsonUrl =
+        type === 'file'
+          ? `${baseUrl}/${id}/file/backing.json`
+          : `${baseUrl}/${id}/backing.json`;
       const searchParams = new URLSearchParams({
         data: JSON.stringify({ jsonUrl }),
         redirect: `${baseUrl}/monthly-plan/confirmation`,

--- a/src/pages/profile.js
+++ b/src/pages/profile.js
@@ -97,16 +97,11 @@ export default class Profile extends React.Component {
   }
 
   handleBackMyStack = async () => {
-    try {
-      const savedProfileUrl = await this.saveProfileToS3();
-      const profileId = savedProfileUrl.Key.split('/')[0];
-      await Router.pushRoute('monthly-plan', {
-        id: profileId,
-        type: 'profile',
-      });
-    } catch (err) {
-      console.error(err);
-    }
+    const { id } = this.props;
+    await Router.pushRoute('monthly-plan', {
+      id,
+      type: 'profile',
+    });
   };
 
   render() {


### PR DESCRIPTION
Currently for organization profile, we save repository files and analyze them during dispatch,  this approach does not work effectively with organizations and personal profiles with large numbers of repositories like airbnb with over 53 savable repository package files. Fetching these files from s3 and analyzing them takes time leading to server time out during dispatch. 

This PR attempts to fix this by removing the process of saving organization public repository files on s3, instead they're fetched directly from github and analyzed using [`getProfileData`](https://github.com/opencollective/backyourstack/blob/master/src/server/index.js#L232)  method through `'/:id/backing.json'` endpoint. This will allow us to benefit from internal cache, thereby speeding up the process. 

#### What about private repositories?
We can save only private repository on s3  but we first have to figure this #228 first.