### PR TITLE
Update confirmation page for asynchronous dispatch 

### DIFF
--- a/src/components/BackMyStack.js
+++ b/src/components/BackMyStack.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 
-const BackMyStack = ({ onClickBackMyStack }) => {
+const BackMyStack = ({ onClickBackMyStack, saving }) => {
   return (
     <Fragment>
       <style jsx>
@@ -105,6 +105,10 @@ const BackMyStack = ({ onClickBackMyStack }) => {
           .backMyStackBtn:hover {
             opacity: 0.8;
           }
+          .backMyStackBtn:disabled {
+            opacity: 0.8;
+            cursor: default;
+          }
           @media screen and (max-width: 768px),
             @media screen and (max-width: 500px) {
             .backMyStackWrapper {
@@ -146,6 +150,7 @@ const BackMyStack = ({ onClickBackMyStack }) => {
           <button
             className="bigButton backMyStackBtn"
             onClick={onClickBackMyStack}
+            disabled={saving}
           >
             Back My Stack
           </button>
@@ -157,6 +162,7 @@ const BackMyStack = ({ onClickBackMyStack }) => {
 
 BackMyStack.propTypes = {
   onClickBackMyStack: PropTypes.func,
+  saving: PropTypes.bool,
 };
 
 export default BackMyStack;

--- a/src/lib/opencollective.js
+++ b/src/lib/opencollective.js
@@ -101,12 +101,7 @@ const getAllCollectivesQuery = `query allCollectives(
 const backyourstackDispatchOrderMutation = `
   mutation backyourstackDispatchOrder($id: Int!) {
     backyourstackDispatchOrder(id: $id) {
-      id
-      totalAmount
-      collective {
-        name
-        slug
-      }
+      dispatching
     }
   }
 `;

--- a/src/lib/s3.js
+++ b/src/lib/s3.js
@@ -91,7 +91,7 @@ export const getFiles = async id => {
   return data;
 };
 
-export const getProfilePrivateData = async id => {
+export const getProfileSavedData = async id => {
   const data = await getFiles(id);
   if (!data) {
     return null;

--- a/src/pages/monthly-plan-confirmation.js
+++ b/src/pages/monthly-plan-confirmation.js
@@ -154,7 +154,7 @@ export default class MonthlyPlanConfirmation extends React.Component {
               </div>
             )}
             {status === 'dispatching' && (
-              <div className="confirmationWrapper">
+              <div className="contentCard">
                 <h3>Dispatch in process</h3>
                 <p>
                   Your first payment is currently being dispatched, you&apos;ll

--- a/src/pages/monthly-plan-confirmation.js
+++ b/src/pages/monthly-plan-confirmation.js
@@ -47,15 +47,14 @@ export default class MonthlyPlanConfirmation extends React.Component {
         });
       } else {
         this.setState({
-          status: 'success',
-          dispatchedOrders: data,
+          status: 'dispatching',
         });
       }
     });
   }
 
   render() {
-    const { dispatchedOrders, status, errMesg } = this.state;
+    const { status, errMesg } = this.state;
     return (
       <div className="Page ConfirmPage">
         <style jsx global>
@@ -88,75 +87,11 @@ export default class MonthlyPlanConfirmation extends React.Component {
               color: #76777a;
               box-sizing: border-box;
             }
-            .confirmationWrapper h1 {
-              font-weight: 900;
-              font-size: 32px;
-              line-height: 36px;
-              letter-spacing: -0.4px;
-              color: #141414;
-            }
-            .confirmationWrapper h3 {
-              font-size: 20px;
-              line-height: 22px;
-              letter-spacing: -0.2px;
-              color: #141414;
-            }
-            .tableDescription {
-              font-size: 14px;
-              font-weight: 400;
-            }
-            table {
-              width: 100%;
-              border-collapse: collapse;
-            }
-            table th,
-            table td {
-              border-bottom: 1px solid #dcdee0;
-              padding: 0.5em;
-              white-space: nowrap;
-              font-size: 14px;
-            }
-            table tr th:nth-child(2),
-            table tr td:nth-child(2) {
-              text-align: right;
-            }
-            table tr th:nth-child(1),
-            table tr td:nth-child(1) {
-              text-align: left;
-            }
-            table th {
-              text-transform: uppercase;
-              font-weight: bold;
-              font-size: 10px;
-            }
-            .collectiveLink:hover {
-              color: #76777a;
-            }
-            .note {
-              font-size: 12px;
-              line-height: 18px;
-              color: #4e5052;
-            }
-            .thankYouText {
-              font-size: 20px;
-              line-height: 22px;
-              color: #141414;
-              margin-top: 30px;
-              margin-bottom: 30px;
-            }
             @media screen and (max-width: 640px) {
               .contentWrapper {
                 background: url(/static/img/mobile-background-colors.svg)
                   no-repeat;
                 background-size: 100%;
-              }
-              .confirmationWrapper h1 {
-                font-size: 24px;
-                margin-bottom: 5px;
-              }
-              .confirmationWrapper h3 {
-                font-size: 16px;
-                margin-top: 5px;
               }
               .contentCard {
                 width: 100%;
@@ -218,56 +153,13 @@ export default class MonthlyPlanConfirmation extends React.Component {
                 </a>
               </div>
             )}
-            {status === 'processing' && (
-              <div className="dispatchingWrapper contentCard">
-                <h3>Dispatching...</h3>
-              </div>
-            )}
-            {status === 'success' && (
+            {status === 'dispatching' && (
               <div className="confirmationWrapper">
-                <h1>Woot woot! 🎉</h1>
-                <h3>Your first payment was successfully dispatched.</h3>
-                <div className="tableWrapper contentCard">
-                  <p className="tableDescription">
-                    You&apos;re contributing to the following Collectives:
-                  </p>
-                  <table>
-                    <tr>
-                      <th>Collective</th>
-                      <th>Amount</th>
-                    </tr>
-                    {dispatchedOrders.map(order => {
-                      if (order) {
-                        return (
-                          <tr key={order.id}>
-                            <td>
-                              <a
-                                className="collectiveLink"
-                                href={`${process.env.OPENCOLLECTIVE_BASE_URL}/${order.collective.slug}`}
-                              >
-                                {order.collective.name}
-                              </a>
-                            </td>
-                            <td>${(order.totalAmount / 100).toFixed(2)}</td>
-                          </tr>
-                        );
-                      }
-                    })}
-                  </table>
-                  <p className="tableDescription">
-                    That&apos;s it! You will be charged for the first time
-                    today, then on the 1st of each month from now on. The funds
-                    will be automatically distributed to your dependencies.
-                  </p>
-                  <p className="note">
-                    <strong>*Note</strong>: Since the next charge will be on the
-                    1st of the month, you may be charged twice in a short period
-                    if you set this up near the end of the month.
-                  </p>
-                  <h3 className="thankYouText">
-                    Thank you for Backing Your Stack!
-                  </h3>
-                </div>
+                <h3>Dispatch in process</h3>
+                <p>
+                  Your first payment is currently being dispatched, you&apos;ll
+                  be notified via email as soon as the process completes.
+                </p>
               </div>
             )}
           </div>

--- a/src/pages/profile.js
+++ b/src/pages/profile.js
@@ -62,6 +62,9 @@ export default class Profile extends React.Component {
 
   constructor(props) {
     super(props);
+    this.state = {
+      saving: false,
+    };
     this.showBackMyStack =
       props.showBackMyStack === 'true' ||
       process.env.SHOW_BACK_MY_STACK === 'true';
@@ -96,13 +99,17 @@ export default class Profile extends React.Component {
   }
 
   handleBackMyStack = async () => {
+    this.setState({ saving: true });
+
     try {
       const { id } = await this.saveProfileToS3();
+      this.setState({ saving: false });
       await Router.pushRoute('monthly-plan', {
         id: id,
         type: 'profile',
       });
     } catch (err) {
+      this.setState({ saving: false });
       console.error(err);
     }
   };
@@ -301,7 +308,10 @@ export default class Profile extends React.Component {
 
             <main>
               {this.showBackMyStack && (
-                <BackMyStack onClickBackMyStack={this.handleBackMyStack} />
+                <BackMyStack
+                  saving={this.state.saving}
+                  onClickBackMyStack={this.handleBackMyStack}
+                />
               )}
               {(!section || section === 'recommendations') && (
                 <RecommendationList


### PR DESCRIPTION
Follwing up https://github.com/opencollective/backyourstack/issues/247#issuecomment-546838595 and in addition to https://github.com/opencollective/opencollective-api/pull/2820

The content of the confirmation page has been updated as shown below:

Part of this update is going back to s3 to save all of repositories for profile, we were only saving private repositories before, to ensure the synchronous process completes on time. Now we can go back to saving all repositories with asynchronous process.

<img width="570" alt="Screenshot 2019-10-29 at 7 48 37 PM" src="https://user-images.githubusercontent.com/15707013/67799150-1c114900-fa85-11e9-8104-c8790556515b.png">
