### PR TITLE
Reorganize how files are saved

### DIFF
--- a/src/lib/s3.js
+++ b/src/lib/s3.js
@@ -12,23 +12,24 @@ const s3 = new S3({
 const Bucket = process.env.AWS_S3_BUCKET;
 
 export const uploadFiles = async files => {
-  const metaData = {};
+  const metadata = { objectKeys: [], files: {} };
   const identifier = uuidv1();
   for (const id in files) {
-    const key = `${identifier}/${id}.json`;
+    const key = `${identifier}/${files[id].name}`;
     const body = { [id]: files[id] };
     const data = await saveFileToS3(key, body);
-    metaData[id] = { url: data.Location };
+    metadata.files[id] = { url: data.Location };
+    metadata.objectKeys = [...metadata.objectKeys, data.Key];
   }
   const folderKey = `${identifier}/dependencies.json`;
-  return saveFileToS3(folderKey, { files: metaData });
+  return saveFileToS3(folderKey, metadata);
 };
 
 export const saveFileToS3 = (Key, Body) => {
   const uploadParam = {
     Bucket,
     Key,
-    Body: JSON.stringify(Body),
+    Body: JSON.stringify(Body, null, 2),
     ACL: 'public-read',
     ContentType: 'application/json',
   };
@@ -36,30 +37,30 @@ export const saveFileToS3 = (Key, Body) => {
 };
 
 export const saveProfile = async (profileId, repos) => {
-  const metaData = { profile: true, files: {} };
+  const metadata = { profile: true, files: {}, objectKeys: [] };
   for (const repo of repos) {
     if (repo.files) {
-      const savedFileUrls = await saveProfileFiles(profileId, repo.files);
-      metaData.files[repo.name] = {
-        urls: [savedFileUrls],
+      const objectKeys = await saveProfileFiles(profileId, repo);
+      metadata.files[repo.name] = {
         private: repo.private,
       };
+      metadata.objectKeys = [...metadata.objectKeys, ...objectKeys];
     }
   }
   const key = `${profileId}/dependencies.json`;
-  const savedFile = await saveFileToS3(key, metaData);
+  const savedFile = await saveFileToS3(key, metadata);
   return savedFile.Key.split('/')[0];
 };
 
-export const saveProfileFiles = async (profileId, files) => {
-  const savedFileUrls = [];
-  for (const file of files) {
-    const key = `${profileId}/${file.id}.json`;
+export const saveProfileFiles = async (profileId, repo) => {
+  const savedObjectKeys = [];
+  for (const file of repo.files) {
+    const key = `${repo.full_name}/${file.name}`;
     const body = { [file.id]: file };
     const data = await saveFileToS3(key, body);
-    savedFileUrls.push(data.Location);
+    savedObjectKeys.push(data.Key);
   }
-  return savedFileUrls;
+  return savedObjectKeys;
 };
 
 export const getObjectList = id => {
@@ -71,24 +72,26 @@ export const getObjectList = id => {
 };
 
 export const getFiles = async id => {
-  const { Contents } = await getObjectList(id);
+  const { objectKeys } = await getObjectsMetadata(id);
   const data = {};
 
-  if (Contents.length === 0) {
+  if (objectKeys.length === 0) {
     return {};
   }
 
-  for (const content of Contents) {
-    // checks if it is the index file and skips over it
-    if (content.Key.indexOf('dependencies') !== -1) {
-      continue;
-    }
-    const params = { Bucket, Key: content.Key };
+  for (const key of objectKeys) {
+    const params = { Bucket, Key: key };
     const { Body } = await s3.getObject(params).promise();
     const file = JSON.parse(Body.toString('utf-8'));
     Object.assign(data, file);
   }
   return data;
+};
+
+export const getObjectsMetadata = async id => {
+  const params = { Bucket, Key: `${id}/dependencies.json` };
+  const { Body } = await s3.getObject(params).promise();
+  return JSON.parse(Body.toString('utf-8'));
 };
 
 export const getProfileSavedData = async id => {

--- a/src/lib/s3.js
+++ b/src/lib/s3.js
@@ -12,13 +12,12 @@ const s3 = new S3({
 const Bucket = process.env.AWS_S3_BUCKET;
 
 export const uploadFiles = async files => {
-  const metadata = { objectKeys: [], files: {} };
+  const metadata = { objectKeys: [] };
   const identifier = uuidv1();
   for (const id in files) {
     const key = `${identifier}/${files[id].name}`;
     const body = { [id]: files[id] };
     const data = await saveFileToS3(key, body);
-    metadata.files[id] = { url: data.Location };
     metadata.objectKeys = [...metadata.objectKeys, data.Key];
   }
   const folderKey = `${identifier}/dependencies.json`;
@@ -37,13 +36,10 @@ export const saveFileToS3 = (Key, Body) => {
 };
 
 export const saveProfile = async (profileId, repos) => {
-  const metadata = { profile: true, files: {}, objectKeys: [] };
+  const metadata = { objectKeys: [] };
   for (const repo of repos) {
     if (repo.files) {
       const objectKeys = await saveProfileFiles(profileId, repo);
-      metadata.files[repo.name] = {
-        private: repo.private,
-      };
       metadata.objectKeys = [...metadata.objectKeys, ...objectKeys];
     }
   }


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/2619

- [x] Saved file renamed as `profile/repository/filename`  i.e `znarf/bouncer/composer.json`

- [x] Add 2 spaces indentation to saved file

<img width="487" alt="Screenshot 2019-11-12 at 2 03 25 PM" src="https://user-images.githubusercontent.com/15707013/68674521-52a39500-0556-11ea-9124-f0e529eec5b9.png">


I mentioned on slack a change in s3 retrieval process on  ["select repository PR"](https://github.com/opencollective/backyourstack/pull/245) in order to not wait for that PR, I have decided to move it to this PR.