### PR TITLE
 Handle permissions for BackYourStack subscribers 

### DIFF
--- a/src/components/MessageBox.js
+++ b/src/components/MessageBox.js
@@ -1,0 +1,60 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+const MessageBox = ({ type, message, onClose }) => {
+  return (
+    <Fragment>
+      <style jsx>
+        {`
+          .messageBoxWrapper {
+            height: 30px;
+            width: 96%;
+            display: flex;
+            border-radius: 15px;
+            padding: 20px;
+            margin-bottom: 20px;
+            justify-content: space-between;
+            align-items: center;
+          }
+          .message {
+            color: #fff;
+          }
+          .error {
+            background: red;
+          }
+          p {
+            font-size: 16px;
+            margin: 0;
+          }
+          button {
+            outline: none;
+            background: none;
+            color: #fff;
+            border: none;
+            cursor: pointer;
+            font-size: 16px;
+          }
+        `}
+      </style>
+      <div
+        className={classnames('messageBoxWrapper', { error: type === 'error' })}
+      >
+        <div className="message">
+          <p>{message}</p>
+        </div>
+        <div className="closeSign">
+          <button onClick={onClose}>X</button>
+        </div>
+      </div>
+    </Fragment>
+  );
+};
+
+MessageBox.propTypes = {
+  type: PropTypes.string.isRequired,
+  message: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default MessageBox;

--- a/src/lib/fetch.js
+++ b/src/lib/fetch.js
@@ -21,7 +21,12 @@ export function getProfileData(id, accessToken, { excludedRepos }) {
 export function fetchJson(url, params = {}) {
   params.credentials = 'same-origin';
   return fetch(url, params)
-    .then(res => res.json())
+    .then(async res => {
+      if (res.ok) {
+        return res.json();
+      }
+      throw new Error(await res.text());
+    })
     .then(fetchDebug);
 }
 

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -122,7 +122,7 @@ async function fetchProfile(login, accessToken) {
   return null;
 }
 
-async function fetchOrgMemebership(orgName, login, accessToken) {
+async function fetchOrgMembership(orgName, login, accessToken) {
   logger.verbose('Fetch organization membership', {
     login: login,
     withAccessToken: !!accessToken,
@@ -277,5 +277,5 @@ export {
   donateToken,
   searchFilesFromRepo,
   silentError,
-  fetchOrgMemebership,
+  fetchOrgMembership,
 };

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -122,6 +122,24 @@ async function fetchProfile(login, accessToken) {
   return null;
 }
 
+async function fetchOrgMemebership(orgName, login, accessToken) {
+  logger.verbose('Fetch organization membership', {
+    login: login,
+    withAccessToken: !!accessToken,
+  });
+
+  const membership = await fetchWithOctokit(
+    'orgs.getMembership',
+    { username: login, org: orgName },
+    accessToken,
+  ).catch(silentError);
+  if (membership) {
+    return membership;
+  }
+
+  return null;
+}
+
 async function fetchReposForProfile(profile, accessToken, loggedInUsername) {
   logger.verbose('Fetch repos for profile', {
     login: profile.login,
@@ -144,7 +162,7 @@ async function fetchReposForProfile(profile, accessToken, loggedInUsername) {
     // https://octokit.github.io/rest.js/#octokit-routes-repos-list
     getReposPath = 'repos.list';
     getReposParameters = { username: profile.login, affiliation: 'owner' };
-  } else if (profile.type == 'Organization') {
+  } else if (profile.type === 'Organization') {
     // https://octokit.github.io/rest.js/#api-Repos-listForOrg
     getReposPath = 'repos.listForOrg';
     getReposParameters = { org: profile.login };
@@ -259,4 +277,5 @@ export {
   donateToken,
   searchFilesFromRepo,
   silentError,
+  fetchOrgMemebership,
 };

--- a/src/lib/s3.js
+++ b/src/lib/s3.js
@@ -94,8 +94,12 @@ export const getFiles = async id => {
 
 export const getObjectsMetadata = async id => {
   const params = { Bucket, Key: `${id}/dependencies.json` };
-  const { Body } = await s3.getObject(params).promise();
-  return JSON.parse(Body.toString('utf-8'));
+  try {
+    const { Body } = await s3.getObject(params).promise();
+    return JSON.parse(Body.toString('utf-8'));
+  } catch (err) {
+    return null;
+  }
 };
 
 export const saveSelectedDependencies = async (id, selectedDependencies) => {

--- a/src/pages/profile.js
+++ b/src/pages/profile.js
@@ -120,13 +120,6 @@ export default class Profile extends React.Component {
   }
 
   handleBackMyStack = async () => {
-    if (!this.props.loggedInUser) {
-      this.setState({
-        error: 'You need to sign in to back your stack',
-      });
-      return;
-    }
-
     NProgress.start();
     this.setState({ saving: true });
 

--- a/src/pages/profile.js
+++ b/src/pages/profile.js
@@ -120,6 +120,13 @@ export default class Profile extends React.Component {
   }
 
   handleBackMyStack = async () => {
+    if (!this.props.loggedInUser) {
+      this.setState({
+        error: 'You need to sign in to back your stack',
+      });
+      return;
+    }
+
     NProgress.start();
     this.setState({ saving: true });
 

--- a/src/pages/profile.js
+++ b/src/pages/profile.js
@@ -18,6 +18,7 @@ import RecommendationList from '../components/RecommendationList';
 import SubscribeForm from '../components/SubscribeForm';
 import BackMyStack from '../components/BackMyStack';
 import BackMyStackCompanyBanner from '../components/BackMyStackCompanyBanner';
+import MessageBox from '../components/MessageBox';
 
 import TwitterLogo from '../static/img/twitter.svg';
 import FacebookLogo from '../static/img/facebook.svg';
@@ -69,6 +70,7 @@ export default class Profile extends React.Component {
     this.state = {
       saving: false,
       repos: props.repos,
+      error: null,
     };
 
     this.showBackMyStack =
@@ -137,9 +139,8 @@ export default class Profile extends React.Component {
       NProgress.done();
       await Router.pushRoute(`/monthly-plan?${searchParams}`);
     } catch (err) {
-      this.setState({ saving: false });
+      this.setState({ saving: false, error: err.message });
       NProgress.done();
-      console.error(err);
     }
   };
 
@@ -370,6 +371,13 @@ export default class Profile extends React.Component {
             </aside>
 
             <main>
+              {this.state.error && (
+                <MessageBox
+                  type="error"
+                  message={this.state.error}
+                  onClose={() => this.setState({ error: null })}
+                />
+              )}
               {this.showBackMyStack && !(order && opencollectiveAccount) && (
                 <BackMyStack
                   saving={this.state.saving}

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -244,7 +244,11 @@ nextApp.prepare().then(() => {
     const dependenciesFile = await getObjectsMetadata(id); // get the content of dependencies.json on s3
     const profileOrder = await getProfileOrder(id);
     // Check if the profile has been saved before
-    if (dependenciesFile && profileOrder) {
+    if (
+      dependenciesFile &&
+      profileOrder &&
+      profileOrder.triggeredBy !== loggedInUsername
+    ) {
       if (!loggedInUsername || !accessToken) {
         return res.status(401).send('You have to sign in to edit profile');
       }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -244,11 +244,7 @@ nextApp.prepare().then(() => {
     const dependenciesFile = await getObjectsMetadata(id); // get the content of dependencies.json on s3
     const profileOrder = await getProfileOrder(id);
     // Check if the profile has been saved before
-    if (
-      dependenciesFile &&
-      profileOrder &&
-      profileOrder.triggeredBy !== loggedInUsername
-    ) {
+    if (dependenciesFile && profileOrder) {
       if (!loggedInUsername || !accessToken) {
         return res.status(401).send('You have to sign in to edit profile');
       }
@@ -273,7 +269,7 @@ nextApp.prepare().then(() => {
           return res
             .status(401)
             .send(
-              'You have to be an active admin of the organization update organization profile.',
+              'You need to be an active admin of this organization to update profile.',
             );
         }
       }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -96,7 +96,10 @@ nextApp.prepare().then(() => {
 
   server.get('/logout', (req, res) => {
     const accessToken = get(req, 'session.passport.user.accessToken');
-    fetchWithBasicAuthentication(GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET)(
+    fetchWithBasicAuthentication(
+      GITHUB_CLIENT_ID,
+      GITHUB_CLIENT_SECRET,
+    )(
       `https://api.github.com/applications/${GITHUB_CLIENT_ID}/grants/${accessToken}`,
       { method: 'DELETE' },
     ).then(() => {
@@ -247,7 +250,8 @@ nextApp.prepare().then(() => {
     // Check if the profile has been saved before
     if (
       metadata &&
-      (profileOrder && profileOrder.triggeredBy !== loggedInUsername)
+      profileOrder &&
+      profileOrder.triggeredBy !== loggedInUsername
     ) {
       if (profile.type === 'User' && loggedInUsername !== profile.login) {
         return res

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -96,7 +96,10 @@ nextApp.prepare().then(() => {
 
   server.get('/logout', (req, res) => {
     const accessToken = get(req, 'session.passport.user.accessToken');
-    fetchWithBasicAuthentication(GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET)(
+    fetchWithBasicAuthentication(
+      GITHUB_CLIENT_ID,
+      GITHUB_CLIENT_SECRET,
+    )(
       `https://api.github.com/applications/${GITHUB_CLIENT_ID}/grants/${accessToken}`,
       { method: 'DELETE' },
     ).then(() => {


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/2622

The following checks are made when a user clicks the 'Back My Stack' button:

- Authentication, the user must be signed in.

- If the github profile about to be saved is an organization, ensure the logged in user is an active admin of the organization

- If the github profile is a personal account, ensure the logged in user profile matches the profile about to be saved.

### How to display errors:

I couldn't decide the best way to display error message regarding permission check on `/profile` page so temporarily  I'm using browser alert as shown below. 

<img width="688" alt="Screenshot 2019-11-13 at 4 20 07 AM" src="https://user-images.githubusercontent.com/15707013/68731243-ae5e3480-05cf-11ea-9f6e-7b17c65ed04d.png">

Not the best way I will love an input from the design team regarding this.