### PR TITLE
Update jsonUrl save on Order

### DIFF
--- a/src/pages/monthly-plan.js
+++ b/src/pages/monthly-plan.js
@@ -117,22 +117,14 @@ export default class MonthlyPlan extends React.Component {
     }
   }
 
-  getContributionUrlData() {
-    const { type, baseUrl, id } = this.props;
-    const jsonUrl =
-      type === 'file'
-        ? `${baseUrl}/${id}/file/backing.json`
-        : `${baseUrl}/${id}/profile/backing.json`;
-
-    return { jsonUrl };
-  }
-
   getContributionUrl = () => {
     // Get the key url of the file
     const { baseUrl, id } = this.props;
     if (id) {
       const searchParams = new URLSearchParams({
-        data: JSON.stringify(this.getContributionUrlData()),
+        data: JSON.stringify({
+          jsonUrl: `${baseUrl}/${id}/backing.json`,
+        }),
         redirect: `${baseUrl}/monthly-plan/confirmation`,
         amount: this.getTotalAmount(),
         skipStepDetails: 'true',

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -11,7 +11,7 @@ import favicon from 'serve-favicon';
 import multer from 'multer';
 import next from 'next';
 import md5 from 'md5';
-import { get, has, pick } from 'lodash';
+import { get, has } from 'lodash';
 
 import routes from '../routes';
 import logger from '../logger';
@@ -255,36 +255,6 @@ nextApp.prepare().then(() => {
   });
 
   server.get('/:id/backing.json', async (req, res) => {
-    const accessToken = get(req, 'session.passport.user.accessToken');
-
-    const profileData = await getProfileData(req.params.id, accessToken);
-    const { recommendations, opencollectiveAccount } = profileData;
-
-    const backing = recommendations
-      .filter(r => r.opencollective)
-      .filter(r => r.opencollective.pledge !== true)
-      .map(recommendation => {
-        const { opencollective, github } = recommendation;
-        const order =
-          opencollectiveAccount &&
-          get(opencollectiveAccount, 'orders.nodes', []).find(
-            order =>
-              opencollective && opencollective.slug === order.toAccount.slug,
-          );
-        if (order) {
-          opencollective.order = order;
-        }
-        return {
-          weight: 100,
-          opencollective: pick(opencollective, ['id', 'name', 'slug', 'order']),
-          github: github,
-        };
-      });
-
-    res.send(backing);
-  });
-
-  server.get('/:id/files/backing.json', async (req, res) => {
     if (!req.params.id) {
       return res.status(400).send('Please provide the file key');
     }


### PR DESCRIPTION
Following up the recent changes, we've updated backing.json endpoint from `/:id/profile/backing.json` and `/:id/file/backing.json` to using just `/:id/files/backing.json` but we did not update jsonUrl sent to open collective as `customData`.