### PR TITLE
chore(silentError): silent error from github file fetching

### DIFF
--- a/src/lib/dependencies/data.js
+++ b/src/lib/dependencies/data.js
@@ -38,6 +38,10 @@ export function getDependenciesFromGithubRepo(githubRepo, githubAccessToken) {
 export function fetchDependenciesFileContent(githubRepo, githubAccessToken) {
   const fileType = languageToFileType[githubRepo.language];
   const manager = dependencyManagers[fileType];
+  if (!manager) {
+    return [];
+  }
+
   return getFirstMatchingFiles(manager, githubRepo, githubAccessToken).catch(
     err => {
       logger.error(
@@ -88,6 +92,9 @@ export function loadDependenciesFromGithubRepo(
   githubAccessToken,
 ) {
   const manager = dependencyManagers[fileType];
+  if (!manager) {
+    return [];
+  }
 
   return getFirstMatchingFiles(manager, githubRepo, githubAccessToken)
     .then(files => files.map(manager.dependencies))


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/2632

This error occurs because some repositories don't have dependencies package files,  this error should be silent.  