### PR TITLE
Save the `order` matching a BackYourStack profile

### DIFF
--- a/src/lib/s3.js
+++ b/src/lib/s3.js
@@ -97,3 +97,7 @@ export const getObjectsMetadata = async id => {
   const { Body } = await s3.getObject(params).promise();
   return JSON.parse(Body.toString('utf-8'));
 };
+
+export const saveProfileOrder = (id, order) => {
+  return saveFileToS3(`${id}/order.json`, order);
+};

--- a/src/pages/monthly-plan-confirmation.js
+++ b/src/pages/monthly-plan-confirmation.js
@@ -9,6 +9,7 @@ import Footer from '../components/Footer';
 export default class MonthlyPlanConfirmation extends React.Component {
   static getInitialProps({ query }) {
     return {
+      id: query.id,
       next: query.next || '/',
       orderId: query.orderId || null,
     };
@@ -17,6 +18,7 @@ export default class MonthlyPlanConfirmation extends React.Component {
   static propTypes = {
     loggedInUser: PropTypes.object,
     orderId: PropTypes.string,
+    id: PropTypes.string,
   };
 
   constructor(props) {
@@ -38,8 +40,9 @@ export default class MonthlyPlanConfirmation extends React.Component {
 
   dispatchOrder(orderId) {
     this.setState({ status: 'processing' });
+    const { id } = this.props;
 
-    postJson('/order/dispatch', { orderId }).then(data => {
+    postJson('/order/dispatch', { id, orderId }).then(data => {
       if (data.error) {
         this.setState({
           status: 'failure',

--- a/src/pages/monthly-plan.js
+++ b/src/pages/monthly-plan.js
@@ -125,7 +125,7 @@ export default class MonthlyPlan extends React.Component {
         data: JSON.stringify({
           jsonUrl: `${baseUrl}/${id}/backing.json`,
         }),
-        redirect: `${baseUrl}/monthly-plan/confirmation`,
+        redirect: `${baseUrl}/${id}/monthly-plan/confirmation`,
         amount: this.getTotalAmount(),
         skipStepDetails: 'true',
       });

--- a/src/routes.js
+++ b/src/routes.js
@@ -11,7 +11,7 @@ routes
   .add('search', '/search')
   .add('files', '/files/:section(dependencies|repositories)?')
   .add('monthly-plan', '/monthly-plan')
-  .add('monthly-plan-confirmation', '/monthly-plan/confirmation')
+  .add('monthly-plan-confirmation', '/:id/monthly-plan/confirmation')
   .add('profile', '/:id/:section(dependencies|repositories)?')
   .add('badge', '/:id/badge/:type(default|compact)?');
 

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -87,7 +87,10 @@ nextApp.prepare().then(() => {
 
   server.get('/logout', (req, res) => {
     const accessToken = get(req, 'session.passport.user.accessToken');
-    fetchWithBasicAuthentication(GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET)(
+    fetchWithBasicAuthentication(
+      GITHUB_CLIENT_ID,
+      GITHUB_CLIENT_SECRET,
+    )(
       `https://api.github.com/applications/${GITHUB_CLIENT_ID}/grants/${accessToken}`,
       { method: 'DELETE' },
     ).then(() => {


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/2624

This PR updates `monthly-confirmation` route path to include `id`. We need  it in order to save `order.json` under the user profile.

#### Nature of saved data

```json
{
  "order":  { "id": 4232 },
   "triggeredBy": "flickz"
}
```