### PR TITLE
feat(bys): save triggedBy if the loggedInUsername is available

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -323,14 +323,18 @@ nextApp.prepare().then(() => {
   });
 
   server.post('/order/dispatch', async (req, res) => {
+    const loggedInUsername = get(req, 'session.passport.user.username');
     const orderId = get(req, 'body.orderId');
     const id = get(req, 'body.id');
+    const order = { id: orderId };
+
+    if (loggedInUsername) {
+      order.triggeredBy = loggedInUsername;
+    }
 
     try {
       const dispatchedOrders = await dispatchOrder(orderId);
-      await saveProfileOrder(id, {
-        id: orderId,
-      });
+      await saveProfileOrder(id, order);
       return res.status(200).send(dispatchedOrders);
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
In order to address `triggeredBy` in permission [PR](https://github.com/opencollective/backyourstack/pull/262), we've concluded that authentication is not required for "Back my stack", so we only want to save `triggeredBy` in `profileOrder` if the user is authenticated during the dispatch process.